### PR TITLE
patches to improve developer ux

### DIFF
--- a/src/cdk/__init__.py
+++ b/src/cdk/__init__.py
@@ -25,14 +25,25 @@ try:
     from .cdk import WalletSqliteDatabase, WalletPostgresDatabase
 except ImportError as e:
     import sys
+
     print(
         "Error: CDK Python bindings not found. "
         "Please run 'just generate' to build the bindings.",
-        file=sys.stderr
+        file=sys.stderr,
     )
     raise ImportError(
         "CDK bindings not generated. Run 'just generate' to build them."
     ) from e
+
+try:
+    from .patches import (  # noqa: F401
+        Amount,
+        _UniffiConverterTypeAmount,
+        CurrencyUnit,
+        _UniffiConverterTypeCurrencyUnit,
+    )
+except (ImportError, AttributeError):
+    pass
 
 
 class Database:

--- a/src/cdk/patches.py
+++ b/src/cdk/patches.py
@@ -1,0 +1,131 @@
+"""
+Patches for generated CDK bindings.
+
+This module contains patches that override certain types and converters
+from the generated cdk.py bindings to provide a better Python experience.
+"""
+
+from enum import Enum
+
+try:
+    from .cdk import _UniffiConverterUInt64, _UniffiConverterRustBuffer
+
+    Amount = int
+
+    class _UniffiConverterTypeAmount(_UniffiConverterRustBuffer):
+        @staticmethod
+        def read(buf):
+            return _UniffiConverterUInt64.read(buf)
+
+        @staticmethod
+        def check_lower(value):
+            _UniffiConverterUInt64.check_lower(value)
+
+        @staticmethod
+        def write(value, buf):
+            _UniffiConverterUInt64.write(value, buf)
+
+except (ImportError, AttributeError):
+    pass
+
+try:
+    from .cdk import _UniffiConverterString, _UniffiConverterRustBuffer, InternalError
+
+    class CurrencyUnit(Enum):
+        SAT = 1
+        MSAT = 2
+        USD = 3
+        EUR = 4
+        AUTH = 5
+        CUSTOM = 6
+
+        def __new__(cls, value):
+            obj = object.__new__(cls)
+            obj._value_ = value
+            obj.unit = None  # type: ignore[attr-defined]
+            return obj
+
+        @staticmethod
+        def custom(unit: str):
+            obj = object.__new__(CurrencyUnit)
+            obj._value_ = CurrencyUnit.CUSTOM.value
+            obj._name_ = "CUSTOM"
+            obj.unit = unit  # type: ignore[attr-defined]
+            return obj
+
+        def is_SAT(self):
+            return self is CurrencyUnit.SAT
+
+        def is_MSAT(self):
+            return self is CurrencyUnit.MSAT
+
+        def is_USD(self):
+            return self is CurrencyUnit.USD
+
+        def is_EUR(self):
+            return self is CurrencyUnit.EUR
+
+        def is_AUTH(self):
+            return self is CurrencyUnit.AUTH
+
+        def is_CUSTOM(self):
+            return self.value == CurrencyUnit.CUSTOM.value
+
+        def __str__(self):
+            if self.is_CUSTOM():
+                return f"CurrencyUnit.CUSTOM(unit={getattr(self, 'unit', None)})"
+            return f"CurrencyUnit.{self.name}()"
+
+        def __eq__(self, other):
+            if not isinstance(other, CurrencyUnit):
+                return False
+            if self.value != other.value:
+                return False
+            if self.is_CUSTOM():
+                return getattr(self, "unit", None) == getattr(other, "unit", None)
+            return True
+
+    class _UniffiConverterTypeCurrencyUnit(_UniffiConverterRustBuffer):
+        @staticmethod
+        def read(buf):
+            variant = buf.read_i32()
+            if variant == CurrencyUnit.SAT.value:
+                return CurrencyUnit.SAT
+            if variant == CurrencyUnit.MSAT.value:
+                return CurrencyUnit.MSAT
+            if variant == CurrencyUnit.USD.value:
+                return CurrencyUnit.USD
+            if variant == CurrencyUnit.EUR.value:
+                return CurrencyUnit.EUR
+            if variant == CurrencyUnit.AUTH.value:
+                return CurrencyUnit.AUTH
+            if variant == CurrencyUnit.CUSTOM.value:
+                unit_str = _UniffiConverterString.read(buf)
+                return CurrencyUnit.custom(unit_str)
+            raise InternalError("Raw enum value doesn't match any cases")
+
+        @staticmethod
+        def check_lower(value):
+            if value.is_SAT():
+                return
+            if value.is_MSAT():
+                return
+            if value.is_USD():
+                return
+            if value.is_EUR():
+                return
+            if value.is_AUTH():
+                return
+            if value.is_CUSTOM():
+                _UniffiConverterString.check_lower(getattr(value, "unit", None))
+                return
+            raise ValueError(value)
+
+        @staticmethod
+        def write(value, buf):
+            buf.write_i32(value.value)
+            if value.is_CUSTOM():
+                _UniffiConverterString.write(getattr(value, "unit", None), buf)
+
+except (ImportError, AttributeError):
+    pass


### PR DESCRIPTION
This PR adds Python patches that override certain types and converters from the generated UniFFI bindings to provide a better Python experience.

## Changes

### 1. `Amount` Type Simplification
- **Before**: `Amount` was a generated class requiring `Amount(value=100)`
- **After**: `Amount` is a simple integer type alias (`Amount = int`)
- **Converter**: `_UniffiConverterTypeAmount` now delegates to `_UniffiConverterUInt64` for serialization

### 2. `CurrencyUnit` Enum Enhancement
- **Before**: Basic generated enum without custom unit support
- **After**: Enhanced enum with:
  - Factory method `CurrencyUnit.custom(unit: str)` for creating custom currency units
  - Helper methods (`is_SAT()`, `is_MSAT()`, etc.) for variant checking
  - Custom `__str__` and `__eq__` methods for better Python integration
  - Proper handling of custom unit strings in the UniFFI converter

## Implementation

Patches are defined in `src/cdk/patches.py` and automatically applied in `src/cdk/__init__.py` after importing the generated bindings. This ensures the patches override the generated code while maintaining compatibility with the UniFFI serialization layer.

## Benefits

- **Simpler API**: `Amount` can be used as a plain integer
- **Better UX**: `CurrencyUnit` supports custom units with proper string representation
- **Type Safety**: Maintains full compatibility with UniFFI type checking and serialization

